### PR TITLE
Don't define `seed:migrate` and `seed:rollback` tasks that already exist

### DIFF
--- a/lib/tasks/seed_migration_tasks.rake
+++ b/lib/tasks/seed_migration_tasks.rake
@@ -1,11 +1,15 @@
 namespace :seed do
-  desc "Run new data migrations."
-  task :migrate => :environment do
-    SeedMigration::Migrator.run_migrations(ENV['MIGRATION'])
+  if !Rake::Task.task_defined?("seed:migrate")
+    desc "Run new data migrations."
+    task :migrate => :environment do
+      SeedMigration::Migrator.run_migrations(ENV['MIGRATION'])
+    end
   end
 
-  desc "Revert last data migration."
-  task :rollback => :environment do
-    SeedMigration::Migrator.rollback_migrations(ENV["MIGRATION"], ENV["STEP"] || ENV["STEPS"] || 1)
+  if !Rake::Task.task_defined?("seed:rollback")
+    desc "Revert last data migration."
+    task :rollback => :environment do
+      SeedMigration::Migrator.rollback_migrations(ENV["MIGRATION"], ENV["STEP"] || ENV["STEPS"] || 1)
+    end
   end
 end


### PR DESCRIPTION
In some applications using Spring I notice that these tasks get defined
twice, which leads to them being executed twice for each attempt. That
is not a big problem with migrating forward, but it can cause annoying
rollbacks if your `down` migration code deletes data you've already
modified since seeding.

Preventing duplication/re-definition of tasks will also prevent
conflicts with user-customized tasks.