### PR TITLE
Rails 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - THREADSAFE=true
   - THREADSAFE=false
 gemfile:
+  - gemfiles/Gemfile.rails-4.2-stable
   - gemfiles/Gemfile.rails-4.1-stable
   - gemfiles/Gemfile.rails-4.0-stable
   - gemfiles/Gemfile.rails-3.2-stable

--- a/gemfiles/Gemfile.rails-4.2-stable
+++ b/gemfiles/Gemfile.rails-4.2-stable
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem "rails", '~> 4.2.4'

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -246,11 +246,12 @@ SeedMigration::Migrator.bootstrap(#{last_migration})
         sorted_attributes[key] = value
       end
 
-      if Rails::VERSION::MAJOR == 3
-        model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s}, :without_protection => true)"
-      elsif Rails::VERSION::MAJOR == 4
-        model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s})"
-      end
+    #   if Rails::VERSION::MAJOR == 3
+    #     model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s}, :without_protection => true)"
+    #   elsif Rails::VERSION::MAJOR == 4
+    #     model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s})"
+    #   end
+      model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s}, :without_protection => true)"
 
       # With pretty indents, please.
       return <<-eos

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -246,12 +246,11 @@ SeedMigration::Migrator.bootstrap(#{last_migration})
         sorted_attributes[key] = value
       end
 
-    #   if Rails::VERSION::MAJOR == 3
-    #     model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s}, :without_protection => true)"
-    #   elsif Rails::VERSION::MAJOR == 4
-    #     model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s})"
-    #   end
-      model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s}, :without_protection => true)"
+      if Rails::VERSION::MAJOR == 3 || defined?(ActiveModel::MassAssignmentSecurity)
+        model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s}, :without_protection => true)"
+      elsif Rails::VERSION::MAJOR == 4
+        model_creation_string = "#{instance.class}.create(#{JSON.parse(sorted_attributes.to_json).to_s})"
+      end
 
       # With pretty indents, please.
       return <<-eos


### PR DESCRIPTION
The code change here just generates the correct `model_creation_string` based on whether `MassAssignmentSecurity` exists, instead of assuming that Rails 4 does not have it.