### PR TITLE
More explicit printout when bootstrapping

### DIFF
--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -107,7 +107,7 @@ module SeedMigration
 
     def self.bootstrap(last_timestamp = nil)
       # replace with logger ?
-      p "Assume migrated up to #{last_timestamp}"
+      p "Assume seed data migrated up to #{last_timestamp}"
       files = get_migration_files(last_timestamp.to_s)
       files.each do |file|
         name = file.split('/').last


### PR DESCRIPTION
This message should be more detailed to avoid confusion with other migrations. (+1 for using a logger also - now it clutters down test output.)