### PR TITLE
Remove `class << self` wrapper for config variables

### DIFF
--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -2,21 +2,19 @@ require 'rails'
 
 module SeedMigration
 
-  class << self
-    mattr_accessor :extend_native_migration_task
-    mattr_accessor :migration_table_name
-    mattr_accessor :ignore_ids
-    mattr_accessor :update_seeds_file
-    mattr_accessor :migrations_path
-    mattr_accessor :use_strict_create
+  mattr_accessor :extend_native_migration_task
+  mattr_accessor :migration_table_name
+  mattr_accessor :ignore_ids
+  mattr_accessor :update_seeds_file
+  mattr_accessor :migrations_path
+  mattr_accessor :use_strict_create
 
-    self.migration_table_name = 'seed_migration_data_migrations' # Hardcoded, evil!
-    self.extend_native_migration_task = false
-    self.ignore_ids = false
-    self.update_seeds_file = true
-    self.migrations_path = 'data'
-    self.use_strict_create = false
-  end
+  self.migration_table_name = 'seed_migration_data_migrations' # Hardcoded, evil!
+  self.extend_native_migration_task = false
+  self.ignore_ids = false
+  self.update_seeds_file = true
+  self.migrations_path = 'data'
+  self.use_strict_create = false
 
   def self.config
     yield self

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -2,6 +2,8 @@ require 'rails'
 
 module SeedMigration
 
+  DEFAULT_TABLE_NAME = 'seed_migration_data_migrations'
+
   mattr_accessor :extend_native_migration_task
   mattr_accessor :migration_table_name
   mattr_accessor :ignore_ids
@@ -9,7 +11,7 @@ module SeedMigration
   mattr_accessor :migrations_path
   mattr_accessor :use_strict_create
 
-  self.migration_table_name = 'seed_migration_data_migrations' # Hardcoded, evil!
+  self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
   self.ignore_ids = false
   self.update_seeds_file = true

--- a/spec/seed_migration_spec.rb
+++ b/spec/seed_migration_spec.rb
@@ -35,4 +35,20 @@ describe SeedMigration do
       SeedMigration.registrar.map(&:model).should include(Product)
     end
   end
+
+  describe 'configuration variables' do
+    it 'does not conflict with variables in other modules' do
+      module Foo
+        class << self
+          mattr_accessor :migration_table_name
+        end
+      end
+
+      Foo.migration_table_name = 'foos'
+      SeedMigration.migration_table_name = 'bars'
+
+      expect(Foo.migration_table_name).to eq 'foos'
+      expect(SeedMigration.migration_table_name).to eq 'bars'
+    end
+  end
 end

--- a/spec/seed_migration_spec.rb
+++ b/spec/seed_migration_spec.rb
@@ -37,6 +37,10 @@ describe SeedMigration do
   end
 
   describe 'configuration variables' do
+    after do
+      SeedMigration.migration_table_name = SeedMigration::DEFAULT_TABLE_NAME
+    end
+
     it 'does not conflict with variables in other modules' do
       module Foo
         class << self


### PR DESCRIPTION
Using `mattr_accessor` within the wrapper for modules can lead to
conflicts with other modules that use the same variable names.

Fixes issue #44