### PR TITLE
Add toggle referential integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Use an initializer file for configuration.
 - `ignore_ids (default=false)`
 - `migration_table_name (default='seed_migration_data_migrations')`: Override the table name for the internal model that holds the migrations
 - `use_strict_create (default=false)`: Use `create!` instead of `create` in `db/seeds.rb` when set to true
-- `disable_referential_integrity (default=false) : Ignore referential integrity when seeding the database
+- `disable_referential_integrity (default=false)` : Ignore referential integrity when seeding the database
 
 #### example:
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Use an initializer file for configuration.
 - `ignore_ids (default=false)`
 - `migration_table_name (default='seed_migration_data_migrations')`: Override the table name for the internal model that holds the migrations
 - `use_strict_create (default=false)`: Use `create!` instead of `create` in `db/seeds.rb` when set to true
+- `disable_referential_integrity (default=false) : Ignore referential integrity when seeding the database
 
 #### example:
 

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -10,6 +10,7 @@ module SeedMigration
   mattr_accessor :update_seeds_file
   mattr_accessor :migrations_path
   mattr_accessor :use_strict_create
+  mattr_accessor :disable_referential_integrity
 
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
@@ -17,6 +18,7 @@ module SeedMigration
   self.update_seeds_file = true
   self.migrations_path = 'data'
   self.use_strict_create = false
+  self.disable_referential_integrity = false
 
   def self.config
     yield self

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -202,8 +202,7 @@ module SeedMigration
         return
       end
       File.open(SEEDS_FILE_PATH, 'w') do |file|
-        if !SeedMigration.disable_referential_integrity
-          file.write <<-eos
+        file.write <<-eos
 # encoding: UTF-8
 # This file is auto-generated from the current content of the database. Instead
 # of editing this file, please use the migrations feature of Seed Migration to
@@ -216,23 +215,14 @@ module SeedMigration
 #
 # It's strongly recommended to check this file into your version control system.
 
+        eos
+        if !SeedMigration.disable_referential_integrity
+          file.write<<-eos
 ActiveRecord::Base.transaction do
           eos
         else
           file.write <<-eos
-# encoding: UTF-8
-# This file is auto-generated from the current content of the database. Instead
-# of editing this file, please use the migrations feature of Seed Migration to
-# incrementally modify your database, and then regenerate this seed file.
-#
-# If you need to create the database on another system, you should be using
-# db:seed, not running all the migrations from scratch. The latter is a flawed
-# and unsustainable approach (the more migrations you'll amass, the slower
-# it'll run and the greater likelihood for issues).
-#
-# It's strongly recommended to check this file into your version control system.
-
-ActiveRecord::Base.connection.disable_referential_integrity
+ActiveRecord::Base.connection.disable_referential_integrity do
   ActiveRecord::Base.transaction do
           eos
         end

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -217,7 +217,7 @@ module SeedMigration
 
         eos
         if !SeedMigration.disable_referential_integrity
-          file.write<<-eos
+          file.write <<-eos
 ActiveRecord::Base.transaction do
           eos
         else


### PR DESCRIPTION
This adds a configuration option called disable_referential_integrity which will put everything in the seeds file into a block where the database connection's referential integrity is disabled using a method called on that connection.

This allows more flexibility when seeding the database.  We ran into an issue where seeding the db with referential integrity enabled caused constraint failures on some many-to-many tables.  Seeding without worrying about referential integrity up front (similar to what a mysql database dump file does) got around this.