### PR TITLE
Fix: Bootstrap versioning bug

### DIFF
--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -20,7 +20,7 @@ module SeedMigration
     def up
       # Check if we already migrated this file
       klass = class_from_path
-      version = @path.basename.to_s.split("_", 2).first
+      version, _ = self.class.parse_migration_filename(@path)
       raise "#{klass} has already been migrated." if SeedMigration::DataMigration.where(version: version).first
 
       start_time = Time.now
@@ -129,9 +129,8 @@ module SeedMigration
       p "Assume seed data migrated up to #{last_timestamp}"
       files = get_migration_files(last_timestamp.to_s)
       files.each do |file|
-        _, version = parse_migration_filename(file)
         migration = SeedMigration::DataMigration.new
-        migration.version = version
+        migration.version, _ = parse_migration_filename(file)
         migration.runtime = 0
         migration.migrated_on = DateTime.now
         migration.save!

--- a/spec/lib/migrator_spec.rb
+++ b/spec/lib/migrator_spec.rb
@@ -72,6 +72,19 @@ describe SeedMigration::Migrator do
     end
   end
 
+  describe '.bootstrap' do
+    let(:timestamp) { 5.days.ago.utc.strftime("%Y%m%d%H%M%S") }
+    before(:each) do
+      FileUtils.rm(SeedMigration::Migrator.get_migration_files)
+      Rails::Generators.invoke("seed_migration", ["TestMigrationBefore", timestamp])
+    end
+
+    it 'runs all migrations' do
+      expect{SeedMigration::Migrator.bootstrap}.to change{SeedMigration::DataMigration.count}.by(1)
+      expect(SeedMigration::DataMigration.first.version).to eq(timestamp)
+    end
+  end
+
   describe "rake tasks" do
     describe "rake migrate" do
       it "should run migrations and insert a record into the data_migrations table" do


### PR DESCRIPTION
- There was a bug where the name of the migration was populated instead of the timestamp in
the versions column of data_migrations table on `rake db:reset`.
- Added tests